### PR TITLE
Add castv2-client to packages.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     	"debug": "^2.1.1",
     	"http": "*",
     	"castv2": "*",
+    	"castv2-client": "*",
     	"mdns-js": "*",
     	"url": "*",
     	"minimist": "*",


### PR DESCRIPTION
castv2-client wasn't automatically installed by npm as a dependency, I had to install it manually to make audio playback work from my Mac