### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:8-stretch
+
+WORKDIR /usr/src/app
+
+COPY . /usr/src/app
+
+RUN npm install
+
+EXPOSE 3000
+
+ENTRYPOINT ["node", "castWebApi.js"]


### PR DESCRIPTION
Adding this single file is enough to allow building [docker](http://www.docker.com) images with a command line as simple as `docker build -t castwebapi https://github.com/vervallsweg/cast-web-api.git`. You can then pass any command line parameters to the image that `castWebApi.js` accepts. If you were so inclined the image produced is suitable for publishing on hub.docker.com through both manual pushing or automated build hooks.