### PR TITLE
Docker: Replace Debian with Alpine to reduce size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
-FROM node:8-stretch
-
+FROM node:alpine
 WORKDIR /usr/src/app
-
+RUN apk add --update git && \
+  rm -rf /tmp/* /var/cache/apk/*
 COPY . /usr/src/app
-
 RUN npm install
-
 EXPOSE 3000
-
 ENTRYPOINT ["node", "castWebApi.js"]


### PR DESCRIPTION
May I suggest to replace node:8-stretch (which is unnecessarily large - 337 MB) with node:alpine (23 MB)?