### PR TITLE
cast-web-api global package

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,31 +6,36 @@ This simple web API is based on the awesome [node-castv2](https://github.com/thi
 However my code is **verry badly written and experimental, not intendend for any production environment!**
 
 ## Installation
-Clone the repo or download a zip version of it
+Install cast-web-api as a command line utility
 
-    $ git clone https://github.com/vervallsweg/cast-web-api.git
-
-Make sure you're in the cloned/downloaded repo and install
-
-	$ npm install
+	$ npm install cast-web-api -g
 
 ## First steps
-You can simply call the script and the web-api should be up and running!
+You can simply run the command and the web-api should be up and running!
 
-    $ node (yourdirectory)/castWebApi.js
+    $ cast-web-api
 
-The server runs on your network ip and 3000. If it cannot determine your ip it defaults to 127.0.0.1. Both parameters can be adjusted with the --hostname --port arguments:
+The server runs on your network IP and port 3000 by default. If it cannot determine your ip it defaults to 127.0.0.1. Both parameters can be adjusted with the `--hostname` and  `--port` arguments:
 
-	$ node (yourdirectory)/castWebApi.js --hostname=192.168.0.11 --port=8080
+	$ cast-web-api --hostname=192.168.0.11 --port=8080
 
 If you'd like to run the API in the background as a daemon [forever](https://github.com/foreverjs/forever "forever") is recommended
 
 	$ npm install forever -g
 
-Running the script and setting the parameters is mostly unchanged:
+Here we pass the path of the command line utility script to Forever:
 
-	$ forever start castWebApi.js
-	$ forever stop castWebApi.js
+	$ forever start `which cast-web-api`
+	$ forever stop `which cast-web-api`
+
+[Linux/OSX only] If you'd like to always run the API in the background even after reboots, you can use crontab.
+
+	$ # While using forever
+	$ (crontab -l 2>/dev/null; echo "@reboot `which forever` `which cast-web-api`")| crontab -
+	$ # While using vanilla node
+	$ (crontab -l 2>/dev/null; echo "@reboot `which node` `which cast-web-api` >> ~/cast-web-api.log")| crontab -
+
+Adjust the command to pass parameters via `crontab -e`. The vanilla node version will log output to `~/cast-web-api.log` e.g. `/home/yourname/cast-web-api.log`.
 
 ## Usage
 

--- a/bin/cast-web-api
+++ b/bin/cast-web-api
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+const castWebApi = require('../castWebApi');

--- a/package.json
+++ b/package.json
@@ -1,14 +1,17 @@
 {
 	"name" : "cast-web-api",
-	"version" : "0.2.3",
+	"version" : "0.3.0",
 	"author" : "Tobias Haerke",
 	"engines": {
-	  	"node": ">= 4.1.0"
+		"node": ">= 6.0.0"
 	},
 	"main": "castWebApi.js",
 	"scripts": {
-      	"cast-web-api": "node ./castWebApi.js"
+		"start": "node ./castWebApi.js"
    	},
+	"bin": {
+		"cast-web-api": "./bin/cast-web-api"
+	},
 	"dependencies": {
     	"debug": "^2.1.1",
     	"http": "*",


### PR DESCRIPTION
This node script is a great candidate for a global package, so I added the ability and made some other small adjustments. If all seems well, you would need to [publish](https://docs.npmjs.com/getting-started/publishing-npm-packages) this module after merging in the changes to make it available for installation.